### PR TITLE
Peerstore implementation

### DIFF
--- a/discovery/service.go
+++ b/discovery/service.go
@@ -28,10 +28,6 @@ func NewDiscovery() (*Discovery, error) {
 	}
 
 	privBytes = gcrypto.FromECDSA(key)
-	if len(privBytes) != secp256k1.PrivKeyBytesLen {
-		return nil, fmt.Errorf("expected secp256k1 data size to be %d", secp256k1.PrivKeyBytesLen)
-	}
-
 	privateKey := (*crypto.Secp256k1PrivateKey)(secp256k1.PrivKeyFromBytes(privBytes))
 
 	nodeConfig := &config.DefaultNodeConfig

--- a/pkg/ethereum/nats.go
+++ b/pkg/ethereum/nats.go
@@ -16,6 +16,7 @@ type PeerDiscoveredEvent struct {
 	Port       int    `json:"port"`
 	CrawlerID  string `json:"crawler_id"`
 	CrawlerLoc string `json:"crawler_location"`
+	Timestamp  int64  `json:"timestamp"`
 }
 
 type MetadataReceivedEvent struct {
@@ -26,6 +27,7 @@ type MetadataReceivedEvent struct {
 	ClientVersion string          `json:"client_version"`
 	CrawlerID     string          `json:"crawler_id"`
 	CrawlerLoc    string          `json:"crawler_location"`
+	Timestamp     int64           `json:"timestamp"` // Timestamp in UNIX milliseconds
 }
 
 func (n *Node) sendMetadataEvent(ctx context.Context, event *MetadataReceivedEvent) {
@@ -72,6 +74,7 @@ func (d *DiscoveryV5) sendPeerEvent(ctx context.Context, node *enode.Node, hInfo
 		Port:       hInfo.Port,
 		CrawlerID:  getCrawlerMachineID(),
 		CrawlerLoc: getCrawlerLocation(),
+		Timestamp:  time.Now().UnixMilli(),
 	}
 
 	select {

--- a/pkg/ethereum/node_notifiee.go
+++ b/pkg/ethereum/node_notifiee.go
@@ -134,11 +134,12 @@ func (n *Node) handleInboundConnection(pid peer.ID) {
 	}()
 
 	// Wait max 5 seconds for the remote status to come in
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	if err := n.waitForStatus(ctx, pid); err != nil {
 		n.log.Warn().Str("peer", pid.String()).Msg("Timed out waiting for status")
+		return
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), n.cfg.DialTimeout)

--- a/pkg/ethereum/peer_dialer.go
+++ b/pkg/ethereum/peer_dialer.go
@@ -41,7 +41,7 @@ func (p *PeerDialer) Serve(ctx context.Context) error {
 			// The success case is handled in net_notifiee.go.
 			timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			if err := p.host.Connect(timeoutCtx, addrInfo); err != nil {
-				p.log.Error().Err(err).Str("peer", addrInfo.ID.String()).Msg("Failed to connect to peer")
+				p.log.Debug().Err(err).Str("peer", addrInfo.ID.String()).Msg("Failed to connect to peer")
 			}
 
 			cancel()

--- a/pkg/ethereum/peerstore.go
+++ b/pkg/ethereum/peerstore.go
@@ -26,15 +26,31 @@ const EPOCH_DURATION = 12 * 32 * time.Second
 
 // PeerInfo contains information about a peer
 type PeerInfo struct {
-	LastSeen   time.Time
+	id         peer.ID
+	lastSeen   time.Time
 	remoteAddr multiaddr.Multiaddr
 
-	status   *eth.Status
-	metadata *eth.MetaDataV1 // Only interested in metadataV1
+	status        *eth.Status
+	metadata      *eth.MetaDataV1 // Only interested in metadataV1
+	clientVersion string
 
 	state          ConnectionState
 	lastErr        error
 	backoffCounter uint32
+}
+
+func (p *PeerInfo) IntoMetadataEvent() *MetadataReceivedEvent {
+	return &MetadataReceivedEvent{
+		ID:            p.id.String(),
+		Multiaddr:     p.remoteAddr.String(),
+		ClientVersion: p.clientVersion,
+		MetaData:      p.metadata,
+		// `epoch = slot // SLOTS_PER_EPOCH`
+		Epoch: uint(p.status.HeadSlot) / 32,
+		// These should be set later
+		CrawlerID:  "",
+		CrawlerLoc: "",
+	}
 }
 
 type Peerstore struct {
@@ -65,8 +81,9 @@ func (p *Peerstore) Insert(id peer.ID, addr multiaddr.Multiaddr) {
 	defer p.Unlock()
 
 	p.peers[id] = &PeerInfo{
+		id:         id,
 		remoteAddr: addr,
-		LastSeen:   time.Now(),
+		lastSeen:   time.Now(),
 	}
 }
 
@@ -76,10 +93,21 @@ func (p *Peerstore) SetState(id peer.ID, state ConnectionState) {
 
 	if info, ok := p.peers[id]; ok {
 		info.state = state
-		info.LastSeen = time.Now()
+		info.lastSeen = time.Now()
 	} else {
 		panic("peerstore: SetState: peer not found")
 	}
+}
+
+func (p *Peerstore) State(id peer.ID) ConnectionState {
+	p.RLock()
+	defer p.RUnlock()
+
+	if p.peers[id] == nil {
+		return NotConnected
+	}
+
+	return p.peers[id].state
 }
 
 // SetBackoff marks the peer as backed off, increments the backoff counter
@@ -91,7 +119,7 @@ func (p *Peerstore) SetBackoff(id peer.ID, err error) uint32 {
 	if info, ok := p.peers[id]; ok {
 		info.lastErr = err
 		info.backoffCounter++
-		info.LastSeen = time.Now()
+		info.lastSeen = time.Now()
 
 		return info.backoffCounter
 	} else {
@@ -104,7 +132,7 @@ func (p *Peerstore) IsBackedOff(id peer.ID) bool {
 	defer p.RUnlock()
 
 	if info, ok := p.peers[id]; ok {
-		return info.backoffCounter > 0 && time.Since(info.LastSeen) < p.defaultBackoff
+		return info.backoffCounter > 0 && time.Since(info.lastSeen) < p.defaultBackoff
 	}
 
 	return false
@@ -117,7 +145,7 @@ func (p *Peerstore) SetConnected(id peer.ID) {
 
 	if info, ok := p.peers[id]; ok {
 		info.backoffCounter = 0
-		info.LastSeen = time.Now()
+		info.lastSeen = time.Now()
 		info.lastErr = nil
 	} else {
 		panic("peerstore: ResetBackoff: peer not found")
@@ -131,7 +159,7 @@ func (p *Peerstore) SetStatus(id peer.ID, status *eth.Status) {
 
 	if info, ok := p.peers[id]; ok {
 		info.status = status
-		info.LastSeen = time.Now()
+		info.lastSeen = time.Now()
 	} else {
 		panic("peerstore: SetStatus: peer not found")
 	}
@@ -154,21 +182,22 @@ func (p *Peerstore) SetMetadata(id peer.ID, metadata *eth.MetaDataV1) {
 
 	if info, ok := p.peers[id]; ok {
 		info.metadata = metadata
-		info.LastSeen = time.Now()
+		info.lastSeen = time.Now()
 	} else {
 		panic("peerstore: SetMetadata: peer not found")
 	}
 }
 
-func (p *Peerstore) State(id peer.ID) ConnectionState {
-	p.RLock()
-	defer p.RUnlock()
+func (p *Peerstore) SetClientVersion(id peer.ID, version string) {
+	p.Lock()
+	defer p.Unlock()
 
-	if p.peers[id] == nil {
-		return NotConnected
+	if info, ok := p.peers[id]; ok {
+		info.clientVersion = version
+		info.lastSeen = time.Now()
+	} else {
+		panic("peerstore: SetClientVersion: peer not found")
 	}
-
-	return p.peers[id].state
 }
 
 func (p *Peerstore) LastErr(id peer.ID) error {
@@ -201,12 +230,12 @@ func (p *Peerstore) PeersToReconnect() []peer.AddrInfo {
 	for id, info := range p.peers {
 		if info.state == NotConnected {
 			// If the backoff expired, reconnect
-			if info.backoffCounter > 0 && time.Since(info.LastSeen) > p.defaultBackoff*(time.Second*time.Duration(info.backoffCounter)) {
+			if info.backoffCounter > 0 && time.Since(info.lastSeen) > p.defaultBackoff*(time.Second*time.Duration(info.backoffCounter)) {
 				peers = append(peers, peer.AddrInfo{ID: id, Addrs: []multiaddr.Multiaddr{info.remoteAddr}})
 			}
 
 			// If the last error was nil and we haven't seen the peer for an epoch, reconnect
-			if info.lastErr == nil && time.Since(info.LastSeen) > EPOCH_DURATION {
+			if info.lastErr == nil && time.Since(info.lastSeen) > EPOCH_DURATION {
 				peers = append(peers, peer.AddrInfo{ID: id, Addrs: []multiaddr.Multiaddr{info.remoteAddr}})
 			}
 

--- a/pkg/ethereum/peerstore.go
+++ b/pkg/ethereum/peerstore.go
@@ -50,6 +50,7 @@ func (p *PeerInfo) IntoMetadataEvent() *MetadataReceivedEvent {
 		// These should be set later
 		CrawlerID:  "",
 		CrawlerLoc: "",
+		Timestamp:  p.lastSeen.UnixMilli(),
 	}
 }
 
@@ -194,7 +195,6 @@ func (p *Peerstore) SetClientVersion(id peer.ID, version string) {
 
 	if info, ok := p.peers[id]; ok {
 		info.clientVersion = version
-		info.lastSeen = time.Now()
 	} else {
 		panic("peerstore: SetClientVersion: peer not found")
 	}

--- a/pkg/ethereum/peerstore.go
+++ b/pkg/ethereum/peerstore.go
@@ -1,0 +1,217 @@
+package ethereum
+
+import (
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+
+	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+)
+
+// ConnectionState signals the capacity for a connection with a given node.
+// It is used to signal to services and other peers whether a node is reachable.
+type ConnectionState int
+
+const (
+	// NotConnected means no connection to peer, and no extra information (default)
+	NotConnected ConnectionState = iota
+
+	// Connecting means we are in the process of connecting to this peer
+	Connecting
+)
+
+const EPOCH_DURATION = 12 * 32 * time.Second
+
+// PeerInfo contains information about a peer
+type PeerInfo struct {
+	LastSeen   time.Time
+	remoteAddr multiaddr.Multiaddr
+
+	status   *eth.Status
+	metadata *eth.MetaDataV1 // Only interested in metadataV1
+
+	state          ConnectionState
+	lastErr        error
+	backoffCounter uint32
+}
+
+type Peerstore struct {
+	sync.RWMutex
+
+	peers          map[peer.ID]*PeerInfo
+	defaultBackoff time.Duration
+}
+
+// NewPeerstore creates a new peerstore
+func NewPeerstore(defaultBackoff time.Duration) *Peerstore {
+	return &Peerstore{
+		peers:          make(map[peer.ID]*PeerInfo),
+		defaultBackoff: defaultBackoff,
+	}
+}
+
+func (p *Peerstore) Get(id peer.ID) *PeerInfo {
+	p.RLock()
+	defer p.RUnlock()
+
+	return p.peers[id]
+}
+
+// Insert inserts a peer into the peerstore in the `NotConnected` state.
+func (p *Peerstore) Insert(id peer.ID, addr multiaddr.Multiaddr) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.peers[id] = &PeerInfo{
+		remoteAddr: addr,
+		LastSeen:   time.Now(),
+	}
+}
+
+func (p *Peerstore) SetState(id peer.ID, state ConnectionState) {
+	p.Lock()
+	defer p.Unlock()
+
+	if info, ok := p.peers[id]; ok {
+		info.state = state
+		info.LastSeen = time.Now()
+	} else {
+		panic("peerstore: SetState: peer not found")
+	}
+}
+
+// SetBackoff marks the peer as backed off, increments the backoff counter
+// and records the last error. This should only be used on outbound connections.
+func (p *Peerstore) SetBackoff(id peer.ID, err error) uint32 {
+	p.Lock()
+	defer p.Unlock()
+
+	if info, ok := p.peers[id]; ok {
+		info.lastErr = err
+		info.backoffCounter++
+		info.LastSeen = time.Now()
+
+		return info.backoffCounter
+	} else {
+		panic("peerstore: SetErr: peer not found")
+	}
+}
+
+func (p *Peerstore) IsBackedOff(id peer.ID) bool {
+	p.RLock()
+	defer p.RUnlock()
+
+	if info, ok := p.peers[id]; ok {
+		return info.backoffCounter > 0 && time.Since(info.LastSeen) < p.defaultBackoff
+	}
+
+	return false
+
+}
+
+func (p *Peerstore) SetConnected(id peer.ID) {
+	p.Lock()
+	defer p.Unlock()
+
+	if info, ok := p.peers[id]; ok {
+		info.backoffCounter = 0
+		info.LastSeen = time.Now()
+		info.lastErr = nil
+	} else {
+		panic("peerstore: ResetBackoff: peer not found")
+	}
+
+}
+
+func (p *Peerstore) SetStatus(id peer.ID, status *eth.Status) {
+	p.Lock()
+	defer p.Unlock()
+
+	if info, ok := p.peers[id]; ok {
+		info.status = status
+		info.LastSeen = time.Now()
+	} else {
+		panic("peerstore: SetStatus: peer not found")
+	}
+}
+
+func (p *Peerstore) Status(id peer.ID) *eth.Status {
+	p.RLock()
+	defer p.RUnlock()
+
+	if p.peers[id] == nil {
+		return nil
+	}
+
+	return p.peers[id].status
+}
+
+func (p *Peerstore) SetMetadata(id peer.ID, metadata *eth.MetaDataV1) {
+	p.Lock()
+	defer p.Unlock()
+
+	if info, ok := p.peers[id]; ok {
+		info.metadata = metadata
+		info.LastSeen = time.Now()
+	} else {
+		panic("peerstore: SetMetadata: peer not found")
+	}
+}
+
+func (p *Peerstore) State(id peer.ID) ConnectionState {
+	p.RLock()
+	defer p.RUnlock()
+
+	if p.peers[id] == nil {
+		return NotConnected
+	}
+
+	return p.peers[id].state
+}
+
+func (p *Peerstore) LastErr(id peer.ID) error {
+	p.RLock()
+	defer p.RUnlock()
+
+	if p.peers[id] == nil {
+		return nil
+	}
+
+	return p.peers[id].lastErr
+}
+
+func (p *Peerstore) Size() int {
+	p.RLock()
+	defer p.RUnlock()
+
+	return len(p.peers)
+}
+
+// PeersToReconnect returns the peers that we need to reconnect to. This includes
+// the not connected peers that have an expired backoff, but also the succesfully connected
+// peers that have not been seen for 1 epoch.
+func (p *Peerstore) PeersToReconnect() []peer.AddrInfo {
+	var peers []peer.AddrInfo
+
+	p.RLock()
+	defer p.RUnlock()
+
+	for id, info := range p.peers {
+		if info.state == NotConnected {
+			// If the backoff expired, reconnect
+			if info.backoffCounter > 0 && time.Since(info.LastSeen) > p.defaultBackoff*(time.Second*time.Duration(info.backoffCounter)) {
+				peers = append(peers, peer.AddrInfo{ID: id, Addrs: []multiaddr.Multiaddr{info.remoteAddr}})
+			}
+
+			// If the last error was nil and we haven't seen the peer for an epoch, reconnect
+			if info.lastErr == nil && time.Since(info.LastSeen) > EPOCH_DURATION {
+				peers = append(peers, peer.AddrInfo{ID: id, Addrs: []multiaddr.Multiaddr{info.remoteAddr}})
+			}
+
+		}
+	}
+
+	return peers
+}


### PR DESCRIPTION
The peerstore is used to keep track of peers and their associated metadata. It's also aware of time, which means we can use it to periodically reconnect to peers (every epoch for new metadata).

Fixes #8 
Fixes #15