### PR TITLE
feat: add validator data analysis scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 peerstore.db
 *.log
-*.py
 *.parquet
 *.sqlite
 *.sqlite-journal

--- a/scripts/client_count_api.py
+++ b/scripts/client_count_api.py
@@ -31,8 +31,8 @@ if response.status_code == 200:
             continue
         
         print(f"Client Version: {client_version}")
-        print(f"  Total Peers with Validators: {counts['possible_validators']}\n")
-        print(f"  Total Validator Count: {counts['total_validators']}")
+        print(f"  Total Peers with Validators: {counts['possible_validators']}")
+        print(f"  Total Validator Count: {counts['total_validators']}\n")
 
 else:
     print(f"Failed to retrieve data from API. Status code: {response.status_code}")

--- a/scripts/client_count_db.py
+++ b/scripts/client_count_db.py
@@ -1,0 +1,64 @@
+import sqlite3
+from collections import defaultdict
+import re
+
+# Connect to the SQLite database
+conn = sqlite3.connect('/Users/namangarg/Downloads/validator_tracker.sqlite')
+
+# Create a cursor object
+cursor = conn.cursor()
+
+# Query to retrieve the data
+query = """
+SELECT peer_id, enr, multiaddr, ip, port, last_seen, last_epoch, client_version, possible_validator, max_validator_count, num_observations 
+FROM validator_tracker
+"""
+
+# Function to extract the client name from the client version string
+def get_client_name(client_version):
+    match = re.match(r"(\w+)", client_version)
+    if match:
+        return match.group(1)
+    return client_version
+
+# Define the client categories
+client_categories = ['prysm', 'lodestar', 'lighthouse', 'nimbus', 'teku', 'grandine', 'erigon', 'other']
+
+# Function to categorize the client name
+def categorize_client(client_version):
+    client_version_lower = client_version.lower()
+    for category in client_categories[:-1]:
+        if category in client_version_lower:
+            return category
+    return 'other'
+
+# Execute the query
+cursor.execute(query)
+
+# Fetch all results from the executed query
+data = cursor.fetchall()
+
+# Dictionary to store the results
+client_data = defaultdict(lambda: {"total_validators": 0, "total_peers_with_validators": 0})
+
+# Process each entry in the fetched data
+for entry in data:
+    peer_id, enr, multiaddr, ip, port, last_seen, last_epoch, client_version, possible_validator, max_validator_count, num_observations = entry
+
+    client_category = categorize_client(client_version)
+
+    client_data[client_category]["total_validators"] += max_validator_count
+    if possible_validator:
+        client_data[client_category]["total_peers_with_validators"] += 1
+
+# Output the results
+for client_version, counts in client_data.items():
+    # if counts["possible_validators"] == 0:
+    #         continue
+        
+    print(f"Client Version: {client_version}")
+    print(f"  Total Peers with Validators: {counts['total_peers_with_validators']}")
+    print(f"  Total Validator Count: {counts['total_validators']}\n")
+
+# Close the connection
+conn.close()

--- a/scripts/teku.py
+++ b/scripts/teku.py
@@ -1,0 +1,63 @@
+import re
+
+def parse_logs(log_file_path):
+    teku_peers = {}
+    handshake_errors = {}
+    goodbye_messages = {}
+
+    # Regular expressions to match relevant log lines
+    teku_client_pattern = re.compile(r'client_version=teku/[^ ]+ peer=([a-zA-Z0-9]+)')
+    handshake_error_pattern = re.compile(r'Handshake failed.*error="([^"]+)".*peer=([a-zA-Z0-9]+)')
+    goodbye_message_pattern = re.compile(r'Received goodbye message\s+msg="([^"]+)".*peer=([a-zA-Z0-9]+)')
+
+
+    with open(log_file_path, 'r') as log_file:
+        for line in log_file:
+            # Check for teku client version lines
+            teku_match = teku_client_pattern.search(line)
+            if teku_match:
+                peer_id = teku_match.group(1)
+                if peer_id not in teku_peers:
+                    teku_peers[peer_id] = line.strip()
+
+            # Check for handshake failed lines
+            handshake_error_match = handshake_error_pattern.search(line)
+            if handshake_error_match:
+                error_reason = handshake_error_match.group(1)
+                peer_id = handshake_error_match.group(2)
+                if peer_id in teku_peers and peer_id not in handshake_errors:
+                    handshake_errors[peer_id] = error_reason
+            
+            # Check for goodbye message lines
+            goodbye_message_match = goodbye_message_pattern.search(line)
+            if goodbye_message_match:
+                goodbye_msg = goodbye_message_match.group(1)
+                peer_id = goodbye_message_match.group(2)
+                if peer_id in teku_peers:
+                    goodbye_messages[peer_id] = goodbye_msg
+                
+            
+
+    # Print handshake errors for teku peers
+    print(f"Teku Peers with handshake errors ({len(handshake_errors)}):")
+    for peer_id, error_reason in handshake_errors.items():
+        print(f"Peer ID: {peer_id}, Error: {error_reason}")
+
+    # Print goodbye messages for teku peers
+    print(f"\n Teku Peers with goodbye messages ({len(goodbye_messages)}):")
+    for peer_id, goodbye_msg in goodbye_messages.items():
+        print(f"Peer ID: {peer_id}, Sent Goodbye Message: {goodbye_msg}")
+            
+    
+    # Print peers present in both handshake errors and goodbye messages
+    common_peers = set(handshake_errors.keys()) & set(goodbye_messages.keys())
+    if common_peers:
+        print(f"\n Teku Peers with both the goodbye and handshake failed messages ({len(common_peers)}):")
+        for peer_id in common_peers:
+            print(f"Peer ID: {peer_id}, Sent Goodbye Message and Handshake Failed")
+            
+    
+
+if __name__ == "__main__":
+    log_file_path = 'sentry.log'  # Replace with the path to your log file
+    parse_logs(log_file_path)

--- a/scripts/unique_peer.py
+++ b/scripts/unique_peer.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+def read_and_print_parquet(file_path):
+    try:
+        # Read the Parquet file
+        df = pd.read_parquet(file_path)
+        
+        # Print the contents of the DataFrame
+        print(df)
+        
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    file_path = '/Users/namangarg/code/valtrack/discovery_events.parquet'
+    read_and_print_parquet(file_path)

--- a/scripts/validator.py
+++ b/scripts/validator.py
@@ -31,8 +31,8 @@ if response.status_code == 200:
             continue
         
         print(f"Client Version: {client_version}")
-        print(f"  Total Validator Count: {counts['total_validators']}")
         print(f"  Total Peers with Validators: {counts['possible_validators']}\n")
+        print(f"  Total Validator Count: {counts['total_validators']}")
 
 else:
     print(f"Failed to retrieve data from API. Status code: {response.status_code}")

--- a/scripts/validator.py
+++ b/scripts/validator.py
@@ -1,0 +1,38 @@
+import requests
+from collections import defaultdict
+
+# API endpoint
+url = "http://localhost:8080/validators"
+
+# Make the API request
+response = requests.get(url)
+
+# Check if the request was successful
+if response.status_code == 200:
+    # Parse the JSON response
+    data = response.json()
+
+    # Dictionary to store the results
+    client_data = defaultdict(lambda: {"total_validators": 0, "possible_validators": 0})
+
+    # Process each entry in the response
+    for entry in data:
+        client_version = entry["client_version"]
+        max_validator_count = entry["max_validator_count"]
+        possible_validator = entry["possible_validator"]
+
+        client_data[client_version]["total_validators"] += max_validator_count
+        if possible_validator:
+            client_data[client_version]["possible_validators"] += 1
+
+    # Output the results
+    for client_version, counts in client_data.items():
+        if counts["possible_validators"] == 0:
+            continue
+        
+        print(f"Client Version: {client_version}")
+        print(f"  Total Validator Count: {counts['total_validators']}")
+        print(f"  Total Peers with Validators: {counts['possible_validators']}\n")
+
+else:
+    print(f"Failed to retrieve data from API. Status code: {response.status_code}")


### PR DESCRIPTION
This PR adds a simple Python script that pulls the validator data from the REST API and outputs data.

The output data tells:
- Total Peers with Validators
- Total Validator Count

per `client_version` (if the client version has not validator then it is ignored)