### PR TITLE
chore: improve validator tracker

### DIFF
--- a/consumer/api.go
+++ b/consumer/api.go
@@ -34,7 +34,7 @@ type ValidatorTracker struct {
 	ASNType                string  `json:"asn_type"`
 }
 
-// Query to fetch data from multiple tables
+// Query to fetch data
 var selectQuery = `
 SELECT vt.peer_id, vt.enr, vt.multiaddr, vt.ip, vt.port, vt.last_seen, vt.last_epoch,
 	   vt.client_version, vc.validator_count, 
@@ -100,7 +100,7 @@ func createGetValidatorsHandler(db *sql.DB) http.HandlerFunc {
 				log.Fatalf("Error scanning row: %v\n", err)
 			}
 
-			// If the user is not an admin, we should not return the sensitive data
+			// Dont return sensitive information if not admin
 			if !isAdmin {
 				vm.ENR = ""
 				vm.Multiaddr = ""
@@ -111,7 +111,7 @@ func createGetValidatorsHandler(db *sql.DB) http.HandlerFunc {
 			}
 			vm.ValidatorCountAccuracy = math.Round(vm.ValidatorCountAccuracy*100) / 100
 
-			// Check if this peer_id already exists in the map and update if necessary
+			// Check if peer_id already exists in map, update if the validator count is higher
 			existing, ok := peerIDMap[vm.PeerID]
 			if !ok || vm.ValidatorCount > existing.ValidatorCount {
 				peerIDMap[vm.PeerID] = vm

--- a/consumer/api.go
+++ b/consumer/api.go
@@ -38,7 +38,7 @@ type ValidatorTracker struct {
 var selectQuery = `
 SELECT vt.peer_id, vt.enr, vt.multiaddr, vt.ip, vt.port, vt.last_seen, vt.last_epoch,
 	   vt.client_version, vc.validator_count, 
-	   CAST(vc.n_observations AS FLOAT) / vt.num_observations AS validator_count_accuracy,
+	   CAST(vc.n_observations AS FLOAT) / vt.total_observations AS validator_count_accuracy,
 	   im.hostname, im.city, im.region, im.country, im.latitude, im.longitude,
 	   im.postal_code, im.asn, im.asn_organization, im.asn_type
 FROM validator_tracker vt

--- a/consumer/api.go
+++ b/consumer/api.go
@@ -76,6 +76,9 @@ func createGetValidatorsHandler(db *sql.DB) http.HandlerFunc {
 
 		isAdmin, _ := loadAPIKeys("api_keys.txt", apiKey)
 
+		// Map to store unique entries per peer_id
+		peerIDMap := make(map[string]ValidatorTracker)
+
 		rows, err := db.Query(selectQuery)
 		if err != nil {
 			http.Error(w, "Error querying database", http.StatusInternalServerError)
@@ -106,6 +109,16 @@ func createGetValidatorsHandler(db *sql.DB) http.HandlerFunc {
 				vm.Latitude = math.Round(vm.Latitude*10) / 10
 				vm.Longitude = math.Round(vm.Longitude*10) / 10
 			}
+
+			// Check if this peer_id already exists in the map and update if necessary
+			existing, ok := peerIDMap[vm.PeerID]
+			if !ok || vm.ValidatorCount > existing.ValidatorCount {
+				peerIDMap[vm.PeerID] = vm
+			}
+
+		}
+
+		for _, vm := range peerIDMap {
 			validators = append(validators, vm)
 		}
 

--- a/consumer/api.go
+++ b/consumer/api.go
@@ -21,7 +21,6 @@ type ValidatorTracker struct {
 	LastEpoch         int     `json:"last_epoch"`
 	ClientVersion     string  `json:"client_version"`
 	MaxValidatorCount int     `json:"max_validator_count"`
-	NumObservations   int     `json:"num_observations"`
 	Hostname          string  `json:"hostname,omitempty"`
 	City              string  `json:"city"`
 	Region            string  `json:"region"`
@@ -34,7 +33,7 @@ type ValidatorTracker struct {
 	ASNType           string  `json:"asn_type"`
 }
 
-var selectQuery = `SELECT peer_id, enr, multiaddr, validator_tracker.ip, port, last_seen, last_epoch, client_version, max_validator_count, num_observations, hostname, city, region, country, latitude, longitude, postal_code, asn, asn_organization, asn_type FROM validator_tracker JOIN ip_metadata ON validator_tracker.ip = ip_metadata.ip`
+var selectQuery = `SELECT peer_id, enr, multiaddr, validator_tracker.ip, port, last_seen, last_epoch, client_version, max_validator_count, hostname, city, region, country, latitude, longitude, postal_code, asn, asn_organization, asn_type FROM validator_tracker JOIN ip_metadata ON validator_tracker.ip = ip_metadata.ip`
 
 // LoadAPIKeys reads the API keys from a file and returns a map of keys
 func loadAPIKeys(filePath string, apiKey string) (bool, error) {
@@ -71,7 +70,7 @@ func createGetValidatorsHandler(db *sql.DB) http.HandlerFunc {
 		var validators []ValidatorTracker
 		for rows.Next() {
 			var vm ValidatorTracker
-			err := rows.Scan(&vm.PeerID, &vm.ENR, &vm.Multiaddr, &vm.IP, &vm.Port, &vm.LastSeen, &vm.LastEpoch, &vm.ClientVersion, &vm.MaxValidatorCount, &vm.NumObservations, &vm.Hostname, &vm.City, &vm.Region, &vm.Country, &vm.Latitude, &vm.Longitude, &vm.PostalCode, &vm.ASN, &vm.ASNOrganization, &vm.ASNType)
+			err := rows.Scan(&vm.PeerID, &vm.ENR, &vm.Multiaddr, &vm.IP, &vm.Port, &vm.LastSeen, &vm.LastEpoch, &vm.ClientVersion, &vm.MaxValidatorCount, &vm.Hostname, &vm.City, &vm.Region, &vm.Country, &vm.Latitude, &vm.Longitude, &vm.PostalCode, &vm.ASN, &vm.ASNOrganization, &vm.ASNType)
 			if err != nil {
 				http.Error(w, fmt.Sprintf("Error scanning row: %s", err), http.StatusInternalServerError)
 				return

--- a/consumer/api.go
+++ b/consumer/api.go
@@ -109,6 +109,7 @@ func createGetValidatorsHandler(db *sql.DB) http.HandlerFunc {
 				vm.Latitude = math.Round(vm.Latitude*10) / 10
 				vm.Longitude = math.Round(vm.Longitude*10) / 10
 			}
+			vm.ValidatorCountAccuracy = math.Round(vm.ValidatorCountAccuracy*100) / 100
 
 			// Check if this peer_id already exists in the map and update if necessary
 			existing, ok := peerIDMap[vm.PeerID]

--- a/consumer/db.go
+++ b/consumer/db.go
@@ -229,8 +229,8 @@ func (c *Consumer) runValidatorMetadataEventHandler(token string) error {
 		// is subscribed to a single subnet for a 1 epoch duration
 		currValidatorCount := len(shortLived)
 
-		var prevNumObservations int
-		err = c.db.QueryRow("SELECT total_observations FROM validator_tracker WHERE peer_id = ?", event.ID).Scan(&prevNumObservations)
+		var prevTotalObservations int
+		err = c.db.QueryRow("SELECT total_observations FROM validator_tracker WHERE peer_id = ?", event.ID).Scan(&prevTotalObservations)
 
 		if err == sql.ErrNoRows {
 			// Insert new row
@@ -291,7 +291,7 @@ func (c *Consumer) runValidatorMetadataEventHandler(token string) error {
 			c.log.Error().Err(err).Msg("Error querying validator_tracker database")
 		} else {
 			// Update existing row
-			_, err = tx.Exec(updateTrackerQuery, event.ENR, event.Multiaddr, ip, port, event.Timestamp, event.Epoch, event.ClientVersion, prevNumObservations+1, event.ID)
+			_, err = tx.Exec(updateTrackerQuery, event.ENR, event.Multiaddr, ip, port, event.Timestamp, event.Epoch, event.ClientVersion, prevTotalObservations+1, event.ID)
 			if err != nil {
 				c.log.Error().Err(err).Msg("Error updating row")
 			}

--- a/consumer/db.go
+++ b/consumer/db.go
@@ -113,7 +113,7 @@ func loadIPMetadataFromCSV(db *sql.DB, path string) error {
 	var rowCountStr string
 	err = db.QueryRow("SELECT COUNT(ip) FROM ip_metadata").Scan(&rowCountStr)
 	if err != nil {
-		errors.Wrap(err, "Error querying database")
+		errors.Wrap(err, "Error querying ip_metadata database")
 	}
 
 	rowCount, _ := strconv.Atoi(rowCountStr)
@@ -288,7 +288,7 @@ func (c *Consumer) runValidatorMetadataEventHandler(token string) error {
 			}
 			c.log.Trace().Str("peer_id", event.ID).Msg("Inserted new row")
 		} else if err != nil {
-			c.log.Error().Err(err).Msg("Error querying database")
+			c.log.Error().Err(err).Msg("Error querying validator_tracker database")
 		} else {
 			// Update existing row
 			_, err = tx.Exec(updateTrackerQuery, event.ENR, event.Multiaddr, ip, port, event.Timestamp, event.Epoch, event.ClientVersion, prevNumObservations+1, event.ID)

--- a/consumer/db.go
+++ b/consumer/db.go
@@ -26,7 +26,7 @@ var (
         last_seen INTEGER,
         last_epoch INTEGER,
 		client_version TEXT,
-		num_observations INTEGER
+		total_observations INTEGER
     );
     `
 
@@ -55,12 +55,12 @@ var (
 	);`
 
 	insertTrackerQuery = `
-		INSERT INTO validator_tracker (peer_id, enr, multiaddr, ip, port, last_seen, last_epoch, client_version, num_observations)
+		INSERT INTO validator_tracker (peer_id, enr, multiaddr, ip, port, last_seen, last_epoch, client_version, total_observations)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	updateTrackerQuery = `
 		UPDATE validator_tracker
-		SET enr = ?, multiaddr = ?, ip = ?, port = ?, last_seen = ?, last_epoch = ?, client_version = ?, num_observations = ?
+		SET enr = ?, multiaddr = ?, ip = ?, port = ?, last_seen = ?, last_epoch = ?, client_version = ?, total_observations = ?
 		WHERE peer_id = ?;`
 
 	selectIpMetadataQuery = `SELECT * FROM ip_metadata WHERE ip = ?`
@@ -230,7 +230,7 @@ func (c *Consumer) runValidatorMetadataEventHandler(token string) error {
 		currValidatorCount := len(shortLived)
 
 		var prevNumObservations int
-		err = c.db.QueryRow("SELECT num_observations FROM validator_tracker WHERE peer_id = ?", event.ID).Scan(&prevNumObservations)
+		err = c.db.QueryRow("SELECT total_observations FROM validator_tracker WHERE peer_id = ?", event.ID).Scan(&prevNumObservations)
 
 		if err == sql.ErrNoRows {
 			// Insert new row

--- a/consumer/dune.go
+++ b/consumer/dune.go
@@ -36,22 +36,23 @@ type Column struct {
 }
 
 type ValidatorNonAdminTracker struct {
-	PeerID            string  `json:"peer_id"`
-	Port              int     `json:"port"`
-	LastSeen          int     `json:"last_seen"`
-	LastSeenDate      string  `json:"last_seen_date"`
-	LastEpoch         int     `json:"last_epoch"`
-	ClientVersion     string  `json:"client_version"`
-	MaxValidatorCount int     `json:"max_validator_count"`
-	City              string  `json:"city"`
-	Region            string  `json:"region"`
-	Country           string  `json:"country"`
-	Latitude          float64 `json:"latitude"`
-	Longitude         float64 `json:"longitude"`
-	PostalCode        string  `json:"postal_code"`
-	ASN               string  `json:"asn"`
-	ASNOrganization   string  `json:"asn_organization"`
-	ASNType           string  `json:"asn_type"`
+	PeerID                 string  `json:"peer_id"`
+	Port                   int     `json:"port"`
+	LastSeen               int     `json:"last_seen"`
+	LastSeenDate           string  `json:"last_seen_date"`
+	LastEpoch              int     `json:"last_epoch"`
+	ClientVersion          string  `json:"client_version"`
+	ValidatorCount         int     `json:"validator_count"`
+	ValidatorCountAccuracy float64 `json:"validator_count_accuracy"`
+	City                   string  `json:"city"`
+	Region                 string  `json:"region"`
+	Country                string  `json:"country"`
+	Latitude               float64 `json:"latitude"`
+	Longitude              float64 `json:"longitude"`
+	PostalCode             string  `json:"postal_code"`
+	ASN                    string  `json:"asn"`
+	ASNOrganization        string  `json:"asn_organization"`
+	ASNType                string  `json:"asn_type"`
 }
 
 type Dune struct {
@@ -217,7 +218,8 @@ func (c *Consumer) publishToDune() error {
 		{Name: "last_seen_date", Type: "timestamp", Nullable: true},
 		{Name: "last_epoch", Type: "integer", Nullable: true},
 		{Name: "client_version", Type: "varchar", Nullable: true},
-		{Name: "max_validator_count", Type: "integer", Nullable: true},
+		{Name: "validator_count", Type: "integer", Nullable: true},
+		{Name: "validator_count_accuracy", Type: "double", Nullable: true},
 		{Name: "city", Type: "varchar", Nullable: true},
 		{Name: "region", Type: "varchar", Nullable: true},
 		{Name: "country", Type: "varchar", Nullable: true},

--- a/consumer/dune.go
+++ b/consumer/dune.go
@@ -43,7 +43,6 @@ type ValidatorNonAdminTracker struct {
 	LastEpoch         int     `json:"last_epoch"`
 	ClientVersion     string  `json:"client_version"`
 	MaxValidatorCount int     `json:"max_validator_count"`
-	NumObservations   int     `json:"num_observations"`
 	City              string  `json:"city"`
 	Region            string  `json:"region"`
 	Country           string  `json:"country"`
@@ -219,7 +218,6 @@ func (c *Consumer) publishToDune() error {
 		{Name: "last_epoch", Type: "integer", Nullable: true},
 		{Name: "client_version", Type: "varchar", Nullable: true},
 		{Name: "max_validator_count", Type: "integer", Nullable: true},
-		{Name: "num_observations", Type: "integer", Nullable: true},
 		{Name: "city", Type: "varchar", Nullable: true},
 		{Name: "region", Type: "varchar", Nullable: true},
 		{Name: "country", Type: "varchar", Nullable: true},


### PR DESCRIPTION
Initially in #27 we decided to have `MaxValidatorCount` , after analysis it makes more sense to have the most **frequent** validator count rather than the max.

This PR changes the DB, API, Dune structure to store -
- `ValidatorCount` = most frequent validator count 
- `ValidatorCountAccuracy` = `ValidatorCount`/ `total_observations`